### PR TITLE
[CHORE] 퀴즈 풀이 진행상황을 로컬 스토리지에 저장

### DIFF
--- a/src/main/resources/static/home-script.js
+++ b/src/main/resources/static/home-script.js
@@ -1,5 +1,12 @@
 // 페이지 로드 시 초기화
 document.addEventListener('DOMContentLoaded', () => {
+    // ✅ 저장된 진행 상황이 있으면 quiz.html로 리다이렉션
+    const savedProgress = localStorage.getItem('quizProgress');
+    if (savedProgress) {
+        const data = JSON.parse(savedProgress);
+        window.location.href = `quiz.html?set=${data.quizSet}`;
+        return; // 나머지 초기화 중단
+    }
     initAnimations();
     setupBookmarkTabs();
     setupParallaxEffect();

--- a/src/main/resources/static/quiz.html
+++ b/src/main/resources/static/quiz.html
@@ -15,6 +15,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DB 인덱스 퀴즈</title>
+    <link rel="icon" type="image/png"
+          href="https://quiz-solution-images.s3.ap-northeast-2.amazonaws.com/index-quiz-logo.png">
+    <link rel="stylesheet" href="home-style.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -72,7 +75,7 @@
         <div class="final-result" id="finalResult" style="display: none;">
             <h2>🎉 퀴즈 완료!</h2>
             <div class="score">
-                <p>총 점수: <span id="finalScore">0</span> / <span id="finalTotal" th:text="${#lists.size(quizData)}">10</span></p>
+                <p>총 점수: <span id="finalScore">0</span> / <span id="finalTotal" th:text="${#lists.size(quizData)}">7</span></p>
                 <p class="score-percentage" id="scorePercentage">0%</p>
             </div>
             <div class="final-buttons">

--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -5,6 +5,42 @@ let totalQuestions = 7; // 목데이터 사용 시 2문제, 실제 API는 10문�
 let currentQuestion = null;
 let currentQuestionNumber = null;
 
+// script.js 상단에 추가
+const QuizStorage = {
+    KEY: 'quizProgress',
+
+    save(data) {
+        localStorage.setItem(this.KEY, JSON.stringify(data));
+    },
+
+    load() {
+        const data = localStorage.getItem(this.KEY);
+        return data ? JSON.parse(data) : null;
+    },
+
+    clear() {
+        localStorage.removeItem(this.KEY);
+    }
+};
+// 저장할 데이터 구조: { quizSet, currentQuestionIndex, total, score }
+
+// quiz.html의 홈 버튼에 이벤트 리스너 추가
+document.querySelector('.home-btn').addEventListener('click', (e) => {
+    e.preventDefault();
+
+    const savedProgress = QuizStorage.load();
+
+    if (savedProgress) {
+        const confirmed = confirm('풀던 기록이 모두 삭제됩니다. 홈으로 이동하시겠습니까?');
+        if (confirmed) {
+            QuizStorage.clear();
+            window.location.href = 'index.html';
+        }
+    } else {
+        window.location.href = 'index.html';
+    }
+});
+
 // API 호출 함수
 async function fetchQuestion(questionId) {
     // 실제 API 호출
@@ -284,12 +320,30 @@ function hideLoading() {
 async function initQuiz() {
     console.log('initQuiz() 실행됨');
 
-    const urlParams = new URLSearchParams(window.location.search);
-    quizSet = urlParams.get("set") || "A"; // 기본 A
+    // ✅ 로컬 스토리지 체크 추가
+    const savedProgress = QuizStorage.load();
 
-    quizStartId = (quizSet.charCodeAt(0) - "A".charCodeAt(0)) * 7;
-    currentQuestionIndex = quizStartId;
-    score = 0;
+    if (savedProgress) {
+        // 저장된 진행 상황 복원
+        quizSet = savedProgress.quizSet;
+        quizStartId = (quizSet.charCodeAt(0) - "A".charCodeAt(0)) * 7;
+        currentQuestionIndex = savedProgress.currentQuestionIndex ?? 0;
+        totalQuestions = savedProgress.total ?? 7;
+        score = savedProgress.score;
+
+        if (currentQuestionIndex - quizStartId >= totalQuestions) {
+            showFinalResult();
+            return; // 더 이상 진행하지 않음
+        }
+    } else {
+        // 새로 시작 - URL 파라미터에서 세트 읽기
+        const urlParams = new URLSearchParams(window.location.search);
+        quizSet = urlParams.get("set") || "A";
+        quizStartId = (quizSet.charCodeAt(0) - "A".charCodeAt(0)) * 7;
+        currentQuestionIndex = quizStartId;
+        score = 0;
+    }
+
     selectedAnswers = [];
     isAnswered = false;
 
@@ -541,6 +595,14 @@ async function submitAnswer() {
         if (isCorrect) {
             score++;
         }
+        console.log("currentQuestionIndex : " + currentQuestionIndex);
+
+        QuizStorage.save({
+            quizSet: quizSet,
+            currentQuestionIndex: currentQuestionIndex +1,
+            total : totalQuestions,
+            score: score
+        });
 
         // 모든 선택지에 결과 표시
         const options = document.querySelectorAll('.option');
@@ -622,6 +684,9 @@ async function nextQuestion() {
 
 // 최종 결과 표시
 function showFinalResult() {
+    // ✅ 퀴즈 완료 시 진행 상황 삭제
+    QuizStorage.clear();
+
     quizContainer.style.opacity = '0';
     quizContainer.style.transform = 'translateX(-100px)';
 


### PR DESCRIPTION
# 🚩 연관 이슈
closed #67 

# 🗣️ 리뷰 요구사항 (선택)

# 문제

새로고침하면 풀었던 기록이 모두 초기화된다.

# 목적

풀었던 기록을 유지할 수 있도록 한다.

# 개발 플로우

주고 받는 데이터  : 풀고 있던 문제 세트 + 전체 문제 수 + 풀이 문제 수 + 맞은 문제 수

```sql
const QuizStorage = {
    KEY: 'quizProgress',

    save(data) {
        localStorage.setItem(this.KEY, JSON.stringify(data));
    },

    load() {
        const data = localStorage.getItem(this.KEY);
        return data ? JSON.parse(data) : null;
    },

    clear() {
        localStorage.removeItem(this.KEY);
    }
};
// 저장할 데이터 구조: { quizSet, currentQuestionIndex, total, score }

```

- **유저가 퀴즈 메인 화면 접속 시**
    - 만약 풀었던 기록이 있다면 > 해당 풀었던 화면으로 이동한다
    - 만약 풀었던 기록이 없다면 > 메인 페이지로 이동한다

- **유저가 단일 문제 풀이 시**

    - 풀었던 기록을 업데이트 한다.

- **유저가 하나의 문제 세트 모두 풀이 시** > 풀었던 기록을 flush

- **유저가 풀다가 홈화면으로 이동할 때** > 풀었던 기록 모두 제거 모달창 > 풀었던 기록 flush


### **방법(쿠키 vs 로컬 스토리지) > 로컬 스토리지 활용**

이유1) 서버 단에서 쿠키 파싱 및 만료 로직을 추가하지 않아도 괜찮음

이유2) 쿠키의 잦은 발송은 전반적으로 서버에게 발송할 데이터 크기를 증가시켜 네트워크 비용을 증가시킴

이유3) 쿠키는 브라우저 단에서 자동 발송하므로 쿠키 발송이 필요하지 않은 API에 대해서도 발송됨